### PR TITLE
Featured solution

### DIFF
--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -8,7 +8,7 @@ describe Dashboard do
       expect(Post).to receive(:today).and_return(posts_published_today)
       dashboard = Dashboard.new(posts: Post.all)
 
-      result = dashboard.posts
+      expect(dashboard.posts).to eq posts_published_today
     end
   end
 

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -4,14 +4,11 @@ require "dashboard"
 describe Dashboard do
   describe "#posts" do
     it "returns posts created today" do
-      create :post, title: "first_today", created_at: Time.now.beginning_of_day
-      create :post, title: "last_today", created_at: Time.now.end_of_day
-      create :post, title: "yesterday", created_at: 1.day.ago.end_of_day
+      posts_published_today = double("published_today")
+      expect(Post).to receive(:today).and_return(posts_published_today)
       dashboard = Dashboard.new(posts: Post.all)
 
       result = dashboard.posts
-
-      expect(result.map(&:title)).to match_array(%w(first_today last_today))
     end
   end
 


### PR DESCRIPTION
We are testing the `todays_posts` method from the model Dashboard here. 

We should then call `todays_posts` on `dashboard`, not `posts`.
So the RSpec expectations in this test should be:
```diff
+ expect(dashboard.todays_posts).to eq posts_published_today
- expect(dashboard.posts).to eq posts_published_today
```
We could also rename the test as 
```diff
+ describe "#todays_posts"
- describe "#posts"
```